### PR TITLE
Add provisioningUri() method to time- and counter-based algorithms

### DIFF
--- a/src/main/php/com/google/authenticator/Algorithm.class.php
+++ b/src/main/php/com/google/authenticator/Algorithm.class.php
@@ -10,8 +10,8 @@
  * @test  xp://com.google.authenticator.unittest.CounterBasedTest
  */
 abstract class Algorithm {
-  private $digits, $crypto;
-  protected $secret;
+  private $crypto;
+  protected $digits, $secret;
 
   static function __static() {
     if (!function_exists('hash_equals')) {

--- a/src/main/php/com/google/authenticator/Algorithm.class.php
+++ b/src/main/php/com/google/authenticator/Algorithm.class.php
@@ -10,7 +10,8 @@
  * @test  xp://com.google.authenticator.unittest.CounterBasedTest
  */
 abstract class Algorithm {
-  private $secret, $digits, $crypto;
+  private $digits, $crypto;
+  protected $secret;
 
   static function __static() {
     if (!function_exists('hash_equals')) {

--- a/src/main/php/com/google/authenticator/CounterBased.class.php
+++ b/src/main/php/com/google/authenticator/CounterBased.class.php
@@ -41,10 +41,11 @@ class CounterBased extends Algorithm {
    */
   public function provisioningUri($label, $counter= 0) {
     return sprintf(
-      'otpauth://hotp/%s?secret=%s&counter=%d',
+      'otpauth://hotp/%s?secret=%s&counter=%d%s',
       implode(':', array_map('rawurlencode', (array)$label)),
       $this->secret->encoded(),
-      $counter
+      $counter,
+      6 === $this->digits ? '' : '&digits='.$this->digits
     );
   }
 }

--- a/src/main/php/com/google/authenticator/CounterBased.class.php
+++ b/src/main/php/com/google/authenticator/CounterBased.class.php
@@ -37,15 +37,17 @@ class CounterBased extends Algorithm {
    * 
    * @param  string|string[] $label
    * @param  int $counter
+   * @param  [:string] $parameters
    * @return string
    */
-  public function provisioningUri($label, $counter= 0) {
+  public function provisioningUri($label, $counter= 0, $parameters= []) {
     return sprintf(
-      'otpauth://hotp/%s?secret=%s&counter=%d%s',
+      'otpauth://hotp/%s?secret=%s&counter=%d%s%s',
       implode(':', array_map('rawurlencode', (array)$label)),
       $this->secret->encoded(),
       $counter,
-      6 === $this->digits ? '' : '&digits='.$this->digits
+      6 === $this->digits ? '' : '&digits='.$this->digits,
+      $parameters ? '&'.http_build_query($parameters) : ''
     );
   }
 }

--- a/src/main/php/com/google/authenticator/CounterBased.class.php
+++ b/src/main/php/com/google/authenticator/CounterBased.class.php
@@ -31,4 +31,15 @@ class CounterBased extends Algorithm {
   public function verify($token, $count, Tolerance $tolerance= null) {
     return $this->compare($token, (int)$count, $tolerance);
   }
+
+  /**
+   * Returns provisioning URI
+   * 
+   * @param  string $account
+   * @param  int $counter
+   * @return string
+   */
+  public function provisioningUri($account, $counter= 0) {
+    return sprintf('otpauth://hotp/%s?secret=%s&counter=%d', $account, $this->secret->encoded(), $counter);
+  }
 }

--- a/src/main/php/com/google/authenticator/CounterBased.class.php
+++ b/src/main/php/com/google/authenticator/CounterBased.class.php
@@ -35,11 +35,16 @@ class CounterBased extends Algorithm {
   /**
    * Returns provisioning URI
    * 
-   * @param  string $account
+   * @param  string|string[] $label
    * @param  int $counter
    * @return string
    */
-  public function provisioningUri($account, $counter= 0) {
-    return sprintf('otpauth://hotp/%s?secret=%s&counter=%d', $account, $this->secret->encoded(), $counter);
+  public function provisioningUri($label, $counter= 0) {
+    return sprintf(
+      'otpauth://hotp/%s?secret=%s&counter=%d',
+      implode(':', array_map('rawurlencode', (array)$label)),
+      $this->secret->encoded(),
+      $counter
+    );
   }
 }

--- a/src/main/php/com/google/authenticator/TimeBased.class.php
+++ b/src/main/php/com/google/authenticator/TimeBased.class.php
@@ -78,4 +78,14 @@ class TimeBased extends Algorithm {
     if (null === $time) $time= time();
     return $this->compare($token, (int)($time/ $this->interval), $tolerance);
   }
+
+  /**
+   * Returns provisioning URI
+   * 
+   * @param  string $account
+   * @return string
+   */
+  public function provisioningUri($account) {
+    return sprintf('otpauth://totp/%s?secret=%s', $account, $this->secret->encoded());
+  }
 }

--- a/src/main/php/com/google/authenticator/TimeBased.class.php
+++ b/src/main/php/com/google/authenticator/TimeBased.class.php
@@ -83,15 +83,17 @@ class TimeBased extends Algorithm {
    * Returns provisioning URI
    * 
    * @param  string|string[] $label
+   * @param  [:string] $parameters
    * @return string
    */
-  public function provisioningUri($label) {
+  public function provisioningUri($label, $parameters= []) {
     return sprintf(
-      'otpauth://totp/%s?secret=%s%s%s',
+      'otpauth://totp/%s?secret=%s%s%s%s',
       implode(':', array_map('rawurlencode', (array)$label)),
       $this->secret->encoded(),
       30 === $this->interval ? '' : '&period='.$this->interval,
-      6 === $this->digits ? '' : '&digits='.$this->digits
+      6 === $this->digits ? '' : '&digits='.$this->digits,
+      $parameters ? '&'.http_build_query($parameters) : ''
     );
   }
 }

--- a/src/main/php/com/google/authenticator/TimeBased.class.php
+++ b/src/main/php/com/google/authenticator/TimeBased.class.php
@@ -87,9 +87,11 @@ class TimeBased extends Algorithm {
    */
   public function provisioningUri($label) {
     return sprintf(
-      'otpauth://totp/%s?secret=%s',
+      'otpauth://totp/%s?secret=%s%s%s',
       implode(':', array_map('rawurlencode', (array)$label)),
-      $this->secret->encoded()
+      $this->secret->encoded(),
+      30 === $this->interval ? '' : '&period='.$this->interval,
+      6 === $this->digits ? '' : '&digits='.$this->digits
     );
   }
 }

--- a/src/main/php/com/google/authenticator/TimeBased.class.php
+++ b/src/main/php/com/google/authenticator/TimeBased.class.php
@@ -82,10 +82,14 @@ class TimeBased extends Algorithm {
   /**
    * Returns provisioning URI
    * 
-   * @param  string $account
+   * @param  string|string[] $label
    * @return string
    */
-  public function provisioningUri($account) {
-    return sprintf('otpauth://totp/%s?secret=%s', $account, $this->secret->encoded());
+  public function provisioningUri($label) {
+    return sprintf(
+      'otpauth://totp/%s?secret=%s',
+      implode(':', array_map('rawurlencode', (array)$label)),
+      $this->secret->encoded()
+    );
   }
 }

--- a/src/test/php/com/google/authenticator/unittest/CounterBasedTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/CounterBasedTest.class.php
@@ -86,4 +86,12 @@ class CounterBasedTest {
       (new CounterBased($this->secret))->provisioningUri(['ACME Co', 'account-id'])
     );
   }
+
+  #[Test]
+  public function provisioning_uri_with_digits_other_than_default() {
+    Assert::equals(
+      'otpauth://hotp/account-id?secret=2BX6RYQ4MD5M46KP&counter=0&digits=8',
+      (new CounterBased($this->secret, 8))->provisioningUri('account-id')
+    );
+  }
 }

--- a/src/test/php/com/google/authenticator/unittest/CounterBasedTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/CounterBasedTest.class.php
@@ -62,4 +62,20 @@ class CounterBasedTest {
   public function verify_allowing_previous_and_next($token, $which) {
     Assert::true((new CounterBased($this->secret))->verify($token, 8364950, Tolerance::$PREVIOUS_AND_NEXT), $which);
   }
+
+  #[Test]
+  public function provisioning_uri() {
+    Assert::equals(
+      'otpauth://hotp/account-id?secret=2BX6RYQ4MD5M46KP&counter=0',
+      (new CounterBased($this->secret))->provisioningUri('account-id')
+    );
+  }
+
+  #[Test]
+  public function provisioning_uri_with_counter() {
+    Assert::equals(
+      'otpauth://hotp/account-id?secret=2BX6RYQ4MD5M46KP&counter=10',
+      (new CounterBased($this->secret))->provisioningUri('account-id', 10)
+    );
+  }
 }

--- a/src/test/php/com/google/authenticator/unittest/CounterBasedTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/CounterBasedTest.class.php
@@ -78,4 +78,12 @@ class CounterBasedTest {
       (new CounterBased($this->secret))->provisioningUri('account-id', 10)
     );
   }
+
+  #[Test]
+  public function provisioning_uri_with_label() {
+    Assert::equals(
+      'otpauth://hotp/ACME%20Co:account-id?secret=2BX6RYQ4MD5M46KP&counter=0',
+      (new CounterBased($this->secret))->provisioningUri(['ACME Co', 'account-id'])
+    );
+  }
 }

--- a/src/test/php/com/google/authenticator/unittest/CounterBasedTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/CounterBasedTest.class.php
@@ -94,4 +94,12 @@ class CounterBasedTest {
       (new CounterBased($this->secret, 8))->provisioningUri('account-id')
     );
   }
+
+  #[Test]
+  public function provisioning_uri_with_extra_parameters() {
+    Assert::equals(
+      'otpauth://hotp/account-id?secret=2BX6RYQ4MD5M46KP&counter=0&issuer=Test',
+      (new CounterBased($this->secret))->provisioningUri('account-id', 0, ['issuer' => 'Test'])
+    );
+  }
 }

--- a/src/test/php/com/google/authenticator/unittest/TimeBasedTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/TimeBasedTest.class.php
@@ -101,4 +101,20 @@ class TimeBasedTest {
       (new TimeBased($this->secret))->provisioningUri(['ACME Co', 'account-id'])
     );
   }
+
+  #[Test]
+  public function provisioning_uri_with_digits_other_than_default() {
+    Assert::equals(
+      'otpauth://totp/account-id?secret=2BX6RYQ4MD5M46KP&digits=8',
+      (new TimeBased($this->secret, 30, 8))->provisioningUri('account-id')
+    );
+  }
+
+  #[Test, Values([15, 60])]
+  public function provisioning_uri_with_interval_other_than_default($interval) {
+    Assert::equals(
+      'otpauth://totp/account-id?secret=2BX6RYQ4MD5M46KP&period='.$interval,
+      (new TimeBased($this->secret, $interval))->provisioningUri('account-id')
+    );
+  }
 }

--- a/src/test/php/com/google/authenticator/unittest/TimeBasedTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/TimeBasedTest.class.php
@@ -93,4 +93,12 @@ class TimeBasedTest {
       (new TimeBased($this->secret))->provisioningUri('account-id')
     );
   }
+
+  #[Test]
+  public function provisioning_uri_with_label() {
+    Assert::equals(
+      'otpauth://totp/ACME%20Co:account-id?secret=2BX6RYQ4MD5M46KP',
+      (new TimeBased($this->secret))->provisioningUri(['ACME Co', 'account-id'])
+    );
+  }
 }

--- a/src/test/php/com/google/authenticator/unittest/TimeBasedTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/TimeBasedTest.class.php
@@ -117,4 +117,12 @@ class TimeBasedTest {
       (new TimeBased($this->secret, $interval))->provisioningUri('account-id')
     );
   }
+
+  #[Test]
+  public function provisioning_uri_with_extra_parameters() {
+    Assert::equals(
+      'otpauth://totp/account-id?secret=2BX6RYQ4MD5M46KP&issuer=Test',
+      (new TimeBased($this->secret))->provisioningUri('account-id', ['issuer' => 'Test'])
+    );
+  }
 }

--- a/src/test/php/com/google/authenticator/unittest/TimeBasedTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/TimeBasedTest.class.php
@@ -85,4 +85,12 @@ class TimeBasedTest {
     $t= new TimeBased($this->secret);
     Assert::equals($t->at(time() + $t->interval()), $t->next());
   }
+
+  #[Test]
+  public function provisioning_uri() {
+    Assert::equals(
+      'otpauth://totp/account-id?secret=2BX6RYQ4MD5M46KP',
+      (new TimeBased($this->secret))->provisioningUri('account-id')
+    );
+  }
 }


### PR DESCRIPTION
## Basic usage

```php
// HOTP, otpauth://hotp/{account}?secret={secret}&counter={counter}
$counterbased= new CounterBased($secret);
$uri= $counterbased->provisioningUri($account);             // Start with counter= 0
$uri= $counterbased->provisioningUri($account, $initial);   // Start with counter= $initial

// TOTP, otpauth://totp/{account}?secret={secret}
$timebased= new TimeBased($secret);
$uri= $timebased->provisioningUri($account);
```

## Further usecases

```php
// Pass a map of string to append additional parameters
$uri= $timebased->provisioningUri($account, ['issuer' => 'ACME Co']);

// Pass an array to namespace the account, yields "ACME%20Co:user@example.com"
$uri= $timebased->provisioningUri(['ACME Co', 'user@example.com']);
```

Implements #1 

See also https://github.com/google/google-authenticator/wiki/Key-Uri-Format and https://shkspr.mobi/blog/2022/05/why-is-there-no-formal-specification-for-otpauth-urls/