### PR TITLE
Allow passing util.Secret instances to time- and counter based algorithms directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Working with one-time passwords
 The following shows the API for time-based one-time passwords (TOTP):
 
 ```php
-use com\google\authenticator\{TimeBased, SecretString, Tolerance};
+use com\google\authenticator\{TimeBased, Tolerance};
 use util\Secret;
 
 $secret= new Secret('2BX6RYQ4MD5M46KP');
-$timebased= new TimeBased(new SecretString($secret));
+$timebased= new TimeBased($secret);
 $time= time();
 
 // Get token for a given time
@@ -38,11 +38,11 @@ $verified= $timebased->verify($token, $time, Tolerance::$PREVIOUS_AND_NEXT);
 The following shows the API for counter-based one-time passwords (HOTP):
 
 ```php
-use com\google\authenticator\{CounterBased, SecretString, Tolerance};
+use com\google\authenticator\{CounterBased, Tolerance};
 use util\Secret;
 
 $secret= new Secret('2BX6RYQ4MD5M46KP');
-$counterbased= new CounterBased(new SecretString($secret));
+$counterbased= new CounterBased($secret);
 $counter= 0;
 
 // Get token for a given counter

--- a/src/main/php/com/google/authenticator/Algorithm.class.php
+++ b/src/main/php/com/google/authenticator/Algorithm.class.php
@@ -16,12 +16,12 @@ abstract class Algorithm {
   /**
    * Creates a new one-time-password instance
    *
-   * @param  com.google.authenticator.Secret $secret
+   * @param  util.Secret|com.google.authenticator.Secret $secret
    * @param  int $digits If omitted, defaults to 6
    * @param  string $crypto If omitted, defaults to "sha1"
    */
-  public function __construct(Secret $secret, $digits= 6, $crypto= 'sha1') {
-    $this->secret= $secret;
+  public function __construct($secret, $digits= 6, $crypto= 'sha1') {
+    $this->secret= $secret instanceof Secret ? $secret : new SecretString($secret);
     $this->digits= $digits;
     $this->crypto= $crypto;
   }

--- a/src/main/php/com/google/authenticator/SecretBytes.class.php
+++ b/src/main/php/com/google/authenticator/SecretBytes.class.php
@@ -8,7 +8,7 @@
 class SecretBytes extends Secret {
 
   /**
-   * Creates a new secret string given base32-encoded bytes
+   * Creates a new secret string given raw bytes
    *
    * @param  util.Bytes|string $bytes
    * @throws lang.FormatException

--- a/src/main/php/com/google/authenticator/SecretBytes.class.php
+++ b/src/main/php/com/google/authenticator/SecretBytes.class.php
@@ -1,7 +1,5 @@
 <?php namespace com\google\authenticator;
 
-use util\Bytes;
-
 /**
  * A secret based on raw bytes
  *
@@ -16,10 +14,6 @@ class SecretBytes extends Secret {
    * @throws lang.FormatException
    */
   public function __construct($bytes) {
-    if ($bytes instanceof \lang\types\Bytes) {
-      parent::__construct($bytes->buffer);
-    } else {
-      parent::__construct((string)$bytes);
-    }
+    parent::__construct((string)$bytes);
   }
 }

--- a/src/main/php/com/google/authenticator/SecretString.class.php
+++ b/src/main/php/com/google/authenticator/SecretString.class.php
@@ -5,16 +5,16 @@ use lang\FormatException;
 /**
  * A secret based on a base32-encoded string 
  *
- * @see  http://tools.ietf.org/html/rfc3548
- * @see  http://tools.ietf.org/html/rfc4648
- * @test xp://com.google.authenticator.unittest.SecretStringTest
+ * @see   http://tools.ietf.org/html/rfc3548
+ * @see   http://tools.ietf.org/html/rfc4648
+ * @test  com.google.authenticator.unittest.SecretStringTest
  */
 class SecretString extends Secret {
 
   /**
    * Creates a new secret string given base32-encoded bytes
    *
-   * @param  string|util.Secret|security.SecureString $arg
+   * @param  string|util.Secret $arg
    * @throws lang.FormatException
    */
   public function __construct($arg) {
@@ -34,9 +34,7 @@ class SecretString extends Secret {
       '0' => 0x0e, '1' => 0x0b, '8' => 0x01
     ];
 
-    if ($arg instanceof \security\SecureString) {
-      $encoded= $arg->getCharacters();
-    } else if ($arg instanceof \util\Secret) {
+    if ($arg instanceof \util\Secret) {
       $encoded= $arg->reveal();
     } else {
       $encoded= (string)$arg;

--- a/src/main/php/com/google/authenticator/TimeBased.class.php
+++ b/src/main/php/com/google/authenticator/TimeBased.class.php
@@ -16,12 +16,12 @@ class TimeBased extends Algorithm {
   /**
    * Creates a new time-based one-time-password instance
    *
-   * @param  com.google.authenticator.Secret $secret
+   * @param  util.Secret|com.google.authenticator.Secret $secret
    * @param  int $interval If omitted, uses 30 seconds
    * @param  int $digits If omitted, defaults to 6
    * @param  string $crypto If omitted, defaults to "sha1"
    */
-  public function __construct(Secret $secret, $interval= 30, $digits= 6, $crypto= 'sha1') {
+  public function __construct($secret, $interval= 30, $digits= 6, $crypto= 'sha1') {
     parent::__construct($secret, $digits, $crypto);
     $this->interval= $interval;
   }

--- a/src/test/php/com/google/authenticator/unittest/CounterBasedTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/CounterBasedTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace com\google\authenticator\unittest;
 
-use com\google\authenticator\{CounterBased, SecretString, Tolerance};
-use security\SecureString;
+use com\google\authenticator\{CounterBased, Tolerance};
 use unittest\{Assert, Test, Values};
 use util\Secret;
 
@@ -10,13 +9,7 @@ class CounterBasedTest {
 
   #[Before]
   public function sharedSecret() {
-
-    // FC with newer XP versions, BC with older XP versions
-    if (class_exists(Secret::class)) {
-      $this->secret= new SecretString(new Secret('2BX6RYQ4MD5M46KP'));
-    } else {
-      $this->secret= new SecretString(new SecureString('2BX6RYQ4MD5M46KP'));
-    }
+    $this->secret= new Secret('2BX6RYQ4MD5M46KP');
   }
 
   /** @return var[][] */

--- a/src/test/php/com/google/authenticator/unittest/SecretBytesTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/SecretBytesTest.class.php
@@ -7,9 +7,10 @@ use util\Bytes;
 class SecretBytesTest {
   const BYTES = "\320o\350\342\034`\372\316yO";
 
-  /** @return var[][] */
+  /** @return iterable */
   private function fixtures() {
-    return [[self::BYTES], [new Bytes(self::BYTES)]];
+    yield [self::BYTES];
+    yield [new Bytes(self::BYTES)];
   }
 
   #[Test, Values('fixtures')]

--- a/src/test/php/com/google/authenticator/unittest/SecretStringTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/SecretStringTest.class.php
@@ -2,27 +2,16 @@
 
 use com\google\authenticator\SecretString;
 use lang\FormatException;
-use security\SecureString;
 use unittest\{Assert, Expect, Test, Values};
 use util\{Bytes, Secret};
 
 class SecretStringTest {
   const STRING = '2BX6RYQ4MD5M46KP';
 
-  /** @return var[][] */
+  /** @return iterable */
   private function fixtures() {
-    $fixtures= [[self::STRING]];
-
-    // FC with newer XP versions
-    if (class_exists(Secret::class)) {
-      $fixtures[]= [new Secret(self::STRING)];
-    }
-
-    // BC with older XP versions
-    if (class_exists(SecureString::class)) {
-      $fixtures[]= [new SecureString(self::STRING)];
-    }
-    return $fixtures;
+    yield [self::STRING];
+    yield [new Secret(self::STRING)];
   }
 
   #[Test, Values('fixtures')]

--- a/src/test/php/com/google/authenticator/unittest/TimeBasedTest.class.php
+++ b/src/test/php/com/google/authenticator/unittest/TimeBasedTest.class.php
@@ -1,27 +1,15 @@
 <?php namespace com\google\authenticator\unittest;
 
-use com\google\authenticator\{SecretString, TimeBased, Tolerance};
-use security\SecureString;
+use com\google\authenticator\{TimeBased, Tolerance};
 use unittest\{Assert, Test, Values};
 use util\Secret;
 
 class TimeBasedTest {
   private $secret;
 
-  /**
-   * Sets up test by initializing shared secret
-   *
-   * @return void
-   */
   #[Before]
-  public function setUp() {
-
-    // FC with newer XP versions, BC with older XP versions
-    if (class_exists(Secret::class)) {
-      $this->secret= new SecretString(new Secret('2BX6RYQ4MD5M46KP'));
-    } else {
-      $this->secret= new SecretString(new SecureString('2BX6RYQ4MD5M46KP'));
-    }
+  public function sharedSecret() {
+    $this->secret= new Secret('2BX6RYQ4MD5M46KP');
   }
 
   /** @return var[][] */


### PR DESCRIPTION
Previous code (continues to work):

```php
use com\google\authenticator\{TimeBased, SecretString};
use util\Secret;

$secret= new Secret('2BX6RYQ4MD5M46KP');
$timebased= new TimeBased(new SecretString($secret));
```

New code:

```php
use com\google\authenticator\TimeBased;
use util\Secret;

$secret= new Secret('2BX6RYQ4MD5M46KP');
$timebased= new TimeBased($secret);
```